### PR TITLE
Fix camel-cased xpdConf dir name in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,7 @@ include CHANGELOG.rst
 include LICENSE
 include README.md
 
-recursive-include xpdConf/examples *.yaml
+recursive-include xpdconf/examples *.yaml
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
This fixes the mistaken camel-cased name brought in via #16.

Context: https://github.com/nsls-ii-forge/xpdconf-feedstock/pull/4#issuecomment-789199789.

This is a fixed source-distribution directory structure:
```
$ tree xpdconf-0.4.3
xpdconf-0.4.3
├── AUTHORS.txt
├── CHANGELOG.rst
├── LICENSE
├── MANIFEST.in
├── PKG-INFO
├── README.md
├── setup.cfg
├── setup.py
├── xpdconf
│   ├── __init__.py
│   ├── conf.py
│   ├── examples
│   │   ├── pdf.yaml
│   │   ├── sim.yaml
│   │   ├── sim_db.yaml
│   │   └── xpd.yaml
│   └── tests
│       ├── __init__.py
│       ├── test_base_dir.py
│       ├── test_conf.py
│       └── test_loadyaml.py
└── xpdconf.egg-info
    ├── PKG-INFO
    ├── SOURCES.txt
    ├── dependency_links.txt
    ├── not-zip-safe
    └── top_level.txt

4 directories, 23 files
```